### PR TITLE
fix: temporary file collisions and production path compatibility

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -205,6 +205,7 @@ resource "yandex_function" "ytdl-storage-cleanup" {
   }
 
   environment = {
+    APP_ENV             = "production"
     CLEANUP_MINUTES     = "60"
     YTDL_STORAGE_BUCKET = var.ytdl_storage_bucket_name
     S3_ENDPOINT         = "https://storage.yandexcloud.net"
@@ -371,6 +372,10 @@ resource "yandex_function" "admin-api" {
       bucket = yandex_storage_bucket.video-translate-admin-api-env.bucket
     }
   }
+
+  environment = {
+    APP_ENV = "production"
+  }
 }
 
 resource "yandex_api_gateway" "admin-api-gateway" {
@@ -475,6 +480,10 @@ resource "yandex_function" "vtrans-service" {
     object_storage {
       bucket = yandex_storage_bucket.video-translate-vtrans-service-env.bucket
     }
+  }
+
+  environment = {
+    APP_ENV = "production"
   }
 }
 

--- a/packages/video-translate-bot/src/app.ts
+++ b/packages/video-translate-bot/src/app.ts
@@ -22,6 +22,7 @@ import { DEBUG_ENV, STORAGE_CHANNEL_CHAT_ID, YTDL_STORAGE_BUCKET } from "./env";
 import { downloadMessageFile, useTelegramClient } from "./telegramclient";
 import {
   TEMP_DIR_PATH,
+  getTempFilePath,
   VideoPlatform,
   axiosInstance,
   mixTranslatedVideo,
@@ -205,12 +206,12 @@ app.post(
       const videoBuffer = Buffer.from(videoResponse.data);
       logger.info(`Downloaded video: ${videoBuffer.length}`);
 
-      const videoFilePath = path.join(TEMP_DIR_PATH, "source.mp4");
-      const translatedAudioFilePath = path.join(TEMP_DIR_PATH, "source3.mp3");
+      const videoFilePath = getTempFilePath("source.mp4");
+      const translatedAudioFilePath = getTempFilePath("source3.mp3");
       await fs.writeFile(videoFilePath, videoBuffer);
       await fs.writeFile(translatedAudioFilePath, translateAudioBuffer);
 
-      const resultFilePath = path.join(TEMP_DIR_PATH, "video.mp4");
+      const resultFilePath = getTempFilePath("video.mp4");
       await mixTranslatedVideo(
         videoFilePath,
         translatedAudioFilePath,

--- a/packages/video-translate-bot/src/bot.ts
+++ b/packages/video-translate-bot/src/bot.ts
@@ -104,6 +104,7 @@ import {
   translateVideoFull,
   axiosInstance,
   TEMP_DIR_PATH,
+  getTempFilePath,
   mixTranslatedVideo,
   cleanupOldChannelMessages,
   UnsupportedPlatformError,
@@ -2132,7 +2133,7 @@ bot.action(/.+/, async (context) => {
     // polyfill if duration is not known initially
     // TODO: this must not be executed on thin client, only on worker server
     if (!videoDuration) {
-      const temporaryAudioFilePath = path.join(TEMP_DIR_PATH, "temp.mp3");
+      const temporaryAudioFilePath = getTempFilePath("temp.mp3");
       await fs.writeFile(temporaryAudioFilePath, translateAudioBuffer);
 
       const ffprobeData = await new Promise<FfprobeData>((resolve, reject) =>
@@ -2340,8 +2341,8 @@ bot.action(/.+/, async (context) => {
     // const videoFilePath = "source.mp4";
     // const audioFilePath = "source2.mp3";
     // const translateAudioFilePath = "source3.mp3";
-    const videoFilePath = path.join(TEMP_DIR_PATH, "source.mp4");
-    const translateAudioFilePath = path.join(TEMP_DIR_PATH, "source3.mp3");
+    const videoFilePath = getTempFilePath("source.mp4");
+    const translateAudioFilePath = getTempFilePath("source3.mp3");
 
     // ffmpeg.FS("writeFile", videoFilePath, videoBuffer);
     // // ffmpeg.FS("writeFile", audioFilePath, audioBuffer);
@@ -2512,7 +2513,7 @@ bot.action(/.+/, async (context) => {
         },
         [ActionType.TranslateVideo]: async () => {
           // const resultFilePath = "video.mp4";
-          const resultFilePath = path.join(TEMP_DIR_PATH, "video.mp4");
+          const resultFilePath = getTempFilePath("video.mp4");
 
           // // prettier-ignore
           // await ffmpeg.run(

--- a/packages/video-translate-bot/src/core.ts
+++ b/packages/video-translate-bot/src/core.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosError } from "axios";
 import { Readable } from "stream";
-import { createHash } from "crypto";
+import { createHash, randomBytes } from "crypto";
+import path from "path";
 import { HeadObjectCommand } from "@aws-sdk/client-s3";
 import { logger } from "./logger";
 import {
@@ -788,8 +789,13 @@ export const axiosInstance = axios.create({
 
 // Prefer mounted storage or ephemeral disk for large temporary files.
 // Fallback to /tmp (512MB limit in Yandex Serverless Containers) if no mounted path is available.
-export const TEMP_DIR_PATH = APP_ENV === "local" ? "/tmp" : "/app/tmp";
+export const TEMP_DIR_PATH = "/tmp";
 // process.env.TEMP_DIR_PATH || STORAGE_DIR_PATH || "/tmp";
+
+export const getTempFilePath = (filename: string) => {
+  const name = `${randomBytes(8).toString("hex")}_${filename}`;
+  return path.join(TEMP_DIR_PATH, name);
+};
 
 export const mixTranslatedVideo = (
   videoFilePath: string,


### PR DESCRIPTION
This PR fixes several infrastructure issues in the bot:
1. **Directory Path**: Corrected the temporary directory to `/tmp` for production (Yandex Cloud functions/containers).
2. **Race Conditions**: Implemented unique filenames for temporary audio/video processing to prevent concurrent requests from interfering with each other.
3. **Environment Config**: Added missing `APP_ENV=production` to Terraform function configurations.

These changes resolve the intermittent `ENOENT` and `⚠️ Error! Try again` messages observed during concurrent translation attempts.