### PR TITLE
fix: disable YDB auto-create tables to avoid schema limits

### DIFF
--- a/packages/video-translate-bot/src/db.ts
+++ b/packages/video-translate-bot/src/db.ts
@@ -31,7 +31,7 @@ export const store = Ydb<any>({
   driver,
   driverOptions: { enableReadyCheck: true },
   tableOptions: {
-    shouldCreateTable: true,
+    shouldCreateTable: false,
     tableName: "store",
     keyColumnName: "key",
     sessionColumnName: "value",
@@ -42,12 +42,12 @@ export const sessionStore = Ydb<any>({
   driver,
   driverOptions: { enableReadyCheck: true },
   tableOptions: {
-    shouldCreateTable: true,
+    shouldCreateTable: false,
     tableName: "telegraf-sessions",
   },
 });
 
-const initUpdatesTable = async () => {
+export const initUpdatesTable = async () => {
   await driver.queryClient.do({
     fn: async (session) => {
       await session.execute({


### PR DESCRIPTION
Sets `shouldCreateTable: false` in the `telegraf-session-store-ydb` configuration to prevent *'Request exceeded a limit on the number of schema operations'* errors, which cause timeouts during heavy load (like large video processing).