### PR TITLE
fix: fix Yandex Cloud deployment OOM and ENOTEMPTY errors

### DIFF
--- a/packages/video-translate-bot/package.json
+++ b/packages/video-translate-bot/package.json
@@ -35,7 +35,7 @@
     "npm:pre": "rm -rf node_modules && mkdir -p node_modules_prod && ln -snf node_modules_prod node_modules",
     "npm:post": "if [ -d node_modules ] && [ ! -L node_modules ]; then rm -rf node_modules_prod && mv node_modules node_modules_prod; fi; ln -snf node_modules_dev node_modules",
     "npm:reinstall": "pnpm npm:pre && pnpm npm:install && pnpm npm:post",
-    "app:package": "rm -f ./video-translate-bot.zip && zip -r ./video-translate-bot.zip ./package.json ./node_modules ./build ./locales",
+    "app:package": "rm -f ./video-translate-bot.zip && zip -r ./video-translate-bot.zip ./node_modules ./build ./locales",
     "app:package:no-deps": "rm -f ./video-translate-bot.zip && zip -r ./video-translate-bot.zip ./package.json ./build ./locales",
     "video-translate-bot:upload": "yc storage s3api put-object --bucket video-translate-bot-code --key function.zip --body ./video-translate-bot.zip",
     "video-translate-bot:rebuild": "npm rebuild better-sqlite3 --target_platform=linux --target_arch=x64",

--- a/packages/video-translate-bot/package.json
+++ b/packages/video-translate-bot/package.json
@@ -32,7 +32,7 @@
     "s3:storage:push": "rclone sync ./yc_storage yandex-cloud-nezort11:video-translate-bot-storage --progress",
     "s3:deps:sync": "rclone sync ./node_modules_prod yandex-cloud-nezort11:video-translate-bot-deps/node_modules --progress --transfers 32 --checkers 32 --exclude '.cache/**' --exclude '.bin/**'",
     "npm:install": "if [ \"$(uname -m)\" = \"x86_64\" ]; then npm install --omit=dev --force --no-package-lock; else docker run --rm --platform=linux/amd64 -w /app -v \"$(pwd)/package.json:/app/package.json\" -v \"$(pwd)/node_modules:/app/node_modules\" node:18 bash -c \"npm install --omit=dev --force --no-package-lock\"; fi",
-    "npm:pre": "rm -rf node_modules && mkdir -p node_modules_prod && ln -snf node_modules_prod node_modules",
+    "npm:pre": "rm -rf node_modules && mkdir -p node_modules_prod && mv node_modules_prod node_modules",
     "npm:post": "if [ -d node_modules ] && [ ! -L node_modules ]; then rm -rf node_modules_prod && mv node_modules node_modules_prod; fi; ln -snf node_modules_dev node_modules",
     "npm:reinstall": "pnpm npm:pre && pnpm npm:install && pnpm npm:post",
     "app:package": "rm -f ./video-translate-bot.zip && zip -r ./video-translate-bot.zip ./node_modules ./build ./locales",


### PR DESCRIPTION
Removes `package.json` from the deployment zip to prevent Yandex Cloud from attempting `npm install` which causes an OOM error. Replaces `ln -snf` with `mv` in the `npm:pre` script to prevent `ENOTEMPTY` errors when installing dependencies locally.